### PR TITLE
feat: Implement Spotify music playback system

### DIFF
--- a/commands/voice/join.js
+++ b/commands/voice/join.js
@@ -1,0 +1,71 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { joinVoiceChannel, VoiceConnectionStatus, entersState, getVoiceConnection } = require('@discordjs/voice');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('join')
+    .setDescription('Hace que el bot se una a tu canal de voz.'),
+  async execute(interaction) {
+    const userVoiceChannel = interaction.member.voice.channel;
+
+    if (!userVoiceChannel) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('Debes estar en un canal de voz para usar este comando.');
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+
+    const existingConnection = getVoiceConnection(interaction.guild.id);
+    if (existingConnection) {
+      if (existingConnection.joinConfig.channelId === userVoiceChannel.id) {
+        const infoEmbed = new EmbedBuilder().setColor(0x0099FF).setDescription('Ya estoy conectado a tu canal de voz.');
+        return interaction.reply({ embeds: [infoEmbed], ephemeral: true });
+      }
+      const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('Ya estoy en un canal de voz en este servidor. Usa `/leave` primero si quieres que me mueva.');
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+    
+    if (!userVoiceChannel.joinable) {
+        const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No tengo permisos para unirme a tu canal de voz.');
+        return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+    if (!userVoiceChannel.speakable) { // Though not speaking yet, good to check for future use
+        const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No tengo permisos para hablar en tu canal de voz.');
+        return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+
+    try {
+      const connection = joinVoiceChannel({
+        channelId: userVoiceChannel.id,
+        guildId: interaction.guild.id,
+        adapterCreator: interaction.guild.voiceAdapterCreator,
+        selfDeaf: true, // Bot mutes itself by default
+        selfMute: false
+      });
+
+      connection.on(VoiceConnectionStatus.Disconnected, async (oldState, newState) => {
+        console.warn(`[Voice Connection] Disconnected from ${userVoiceChannel.name} (Guild: ${interaction.guild.name}). State: ${newState.status}`);
+        // This event can be triggered for various reasons (kicked, channel deleted, network issues).
+        // A robust handler might try to reconnect or fully destroy the connection and clean up.
+        // For now, we rely on the 'Destroyed' event (often triggered after 'Disconnected') for full cleanup via play.js.
+        // If a more immediate cleanup is needed here, ensure it coordinates with play.js state.
+        // Example: if (newState.status === VoiceConnectionStatus.Disconnected && newState.reason === VoiceConnectionDisconnectReason.WebSocketClose) connection.destroy();
+      });
+      
+      connection.on(VoiceConnectionStatus.Destroyed, () => {
+        console.log(`[Voice Connection] Connection explicitly destroyed for ${userVoiceChannel.name} (Guild: ${interaction.guild.name}). Cleanup should occur via play.js listeners.`);
+      });
+
+      await entersState(connection, VoiceConnectionStatus.Ready, 20_000); // Reduced timeout slightly
+      const successEmbed = new EmbedBuilder().setColor(0x00FF00).setDescription(`¡Conectado a **${userVoiceChannel.name}**!`);
+      await interaction.reply({ embeds: [successEmbed], ephemeral: true });
+
+    } catch (error) {
+      console.error(`[Voice Join Error] Could not join ${userVoiceChannel.name}: ${error.message}`, error);
+      const currentConnection = getVoiceConnection(interaction.guild.id);
+      if (currentConnection) {
+        currentConnection.destroy();
+      }
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No me pude conectar al canal de voz. Asegúrate de que tengo los permisos correctos y que el canal es accesible.');
+      await interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+  },
+};

--- a/commands/voice/leave.js
+++ b/commands/voice/leave.js
@@ -1,0 +1,60 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { getVoiceConnection, VoiceConnectionStatus } = require('@discordjs/voice');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('leave')
+    .setDescription('Hace que el bot abandone el canal de voz actual y limpia la cola.'),
+  async execute(interaction) {
+    const connection = getVoiceConnection(interaction.guild.id);
+
+    if (!connection) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('No estoy en ningún canal de voz en este servidor.');
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+
+    try {
+      if (connection.state.status === VoiceConnectionStatus.Destroyed) {
+         const infoEmbed = new EmbedBuilder().setColor(0x0099FF).setDescription('Ya me he desconectado o estoy en proceso de ello.');
+         return interaction.reply({ embeds: [infoEmbed], ephemeral: true });
+      }
+
+      // The actual cleanup of guildPlayers and guildQueues map entries
+      // should be handled by the VoiceConnectionStatus.Destroyed listener in play.js.
+      // This command just needs to initiate the destruction of the connection.
+      // Stopping the player and clearing local queue tracks explicitly here is a good immediate measure.
+      
+      const { guildPlayers, guildQueues } = require('./play.js'); // Still need to access for immediate stop/clear.
+      const player = guildPlayers.get(interaction.guild.id);
+      if (player) {
+        player.stop(true); // Stop playback immediately.
+      }
+
+      const queueData = guildQueues.get(interaction.guild.id);
+      if (queueData) {
+        queueData.tracks = []; // Clear tracks array.
+        queueData.currentTrack = null; // Clear current track.
+        if (queueData.nowPlayingMessage) {
+            queueData.nowPlayingMessage.delete().catch(err => console.warn(`[Leave Command] Failed to delete NP message: ${err.message}`));
+            queueData.nowPlayingMessage = null;
+        }
+        // The queueData object itself will be deleted from the guildQueues map by the Destroyed listener in play.js
+      }
+      
+      connection.destroy(); // This will trigger the Destroyed event listeners.
+      
+      const successEmbed = new EmbedBuilder().setColor(0x00FF00).setDescription('He abandonado el canal de voz. La cola ha sido limpiada y la música detenida.');
+      await interaction.reply({ embeds: [successEmbed], ephemeral: true });
+
+    } catch (error) {
+      console.error(`[Voice Leave Error] Could not leave voice channel or clean up: ${error.message}`, error);
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('Ocurrió un error al intentar abandonar el canal de voz.');
+      // Check if interaction has already been replied to, which can happen if an error occurs after an initial reply.
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+      } else {
+        await interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+      }
+    }
+  },
+};

--- a/commands/voice/play.js
+++ b/commands/voice/play.js
@@ -1,0 +1,385 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { 
+  joinVoiceChannel, 
+  createAudioPlayer, 
+  createAudioResource, 
+  AudioPlayerStatus, 
+  VoiceConnectionStatus, 
+  getVoiceConnection, 
+  entersState 
+} = require('@discordjs/voice');
+const playdl = require('play-dl');
+
+const guildPlayers = new Map(); // guildId -> AudioPlayer
+const guildQueues = new Map(); // guildId -> { tracks: [], lastInteractionChannel: null, nowPlayingMessage: null, currentTrack: null }
+
+async function playNextInQueue(guildId, interactionChannel) {
+  const player = guildPlayers.get(guildId);
+  const queueData = guildQueues.get(guildId);
+  const connection = getVoiceConnection(guildId);
+
+  if (!player || !queueData || !connection) {
+    console.log(`[Queue System ${guildId}] Player, queue data, or connection missing. Cannot play next.`);
+    if (queueData && queueData.tracks.length === 0 && queueData.lastInteractionChannel) {
+        const endEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('La cola ha terminado.');
+        queueData.lastInteractionChannel.send({ embeds: [endEmbed] }).catch(console.error);
+    }
+    if (!connection && (player || queueData)) {
+        player?.stop(true); 
+        guildPlayers.delete(guildId);
+        guildQueues.delete(guildId); 
+        console.log(`[Queue System ${guildId}] Cleaned up player/queue due to missing connection.`);
+    }
+    return;
+  }
+
+  if (queueData.tracks.length === 0) {
+    console.log(`[Queue System ${guildId}] Queue is empty. Nothing to play.`);
+    if (queueData.lastInteractionChannel) {
+        const emptyEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('La cola está vacía.');
+        queueData.lastInteractionChannel.send({ embeds: [emptyEmbed] }).catch(console.error);
+    }
+    queueData.currentTrack = null; // Ensure current track is cleared
+    if (queueData.nowPlayingMessage) { // Delete old now playing message if queue is now empty
+        queueData.nowPlayingMessage.delete().catch(err => console.warn("Failed to delete NP message on empty queue:", err.message));
+        queueData.nowPlayingMessage = null;
+    }
+    return;
+  }
+
+  const trackToPlay = queueData.tracks.shift(); 
+  queueData.currentTrack = trackToPlay;
+
+
+  try {
+    console.log(`[Queue System ${guildId}] Attempting to play next track: ${trackToPlay.title}`);
+    const stream = await playdl.stream(trackToPlay.url, { quality: 1 });
+    const resource = createAudioResource(stream.stream, { 
+        inputType: stream.type,
+        metadata: trackToPlay 
+    });
+    
+    player.play(resource);
+    console.log(`[Queue System ${guildId}] Now playing: ${trackToPlay.title}`);
+
+    const nowPlayingEmbed = new EmbedBuilder()
+      .setColor(0x0099FF)
+      .setTitle('Reproduciendo Ahora')
+      .setDescription(`**[${trackToPlay.title}](${trackToPlay.url})**`)
+      .addFields(
+        { name: 'Pedido por', value: trackToPlay.requester, inline: true },
+        { name: 'Duración', value: trackToPlay.duration, inline: true }
+      )
+      .setThumbnail(trackToPlay.thumbnail)
+      .setFooter({ text: `Siguiente en la cola: ${queueData.tracks.length > 0 ? queueData.tracks[0].title : 'Nada'}`});
+
+    const row = new ActionRowBuilder()
+      .addComponents(
+        new ButtonBuilder().setCustomId('music_pause_resume').setLabel('Pausa').setStyle(ButtonStyle.Secondary).setEmoji('⏸️'),
+        new ButtonBuilder().setCustomId('music_skip').setLabel('Saltar').setStyle(ButtonStyle.Primary).setEmoji('⏭️'),
+        new ButtonBuilder().setCustomId('music_stop').setLabel('Detener').setStyle(ButtonStyle.Danger).setEmoji('⏹️'),
+        new ButtonBuilder().setCustomId('music_view_queue').setLabel('Ver Cola').setStyle(ButtonStyle.Secondary).setEmoji('🎶')
+      );
+    
+    if (queueData.nowPlayingMessage) {
+        try {
+            await queueData.nowPlayingMessage.delete();
+        } catch (err) {
+            console.warn(`[Queue System ${guildId}] Could not delete old now playing message: ${err.message}`);
+        }
+    }
+    
+    const channelForMessage = trackToPlay.interactionChannel || queueData.lastInteractionChannel || interactionChannel;
+    if (channelForMessage) {
+        const msg = await channelForMessage.send({ embeds: [nowPlayingEmbed], components: [row] }).catch(console.error);
+        queueData.nowPlayingMessage = msg; 
+    }
+
+  } catch (error) {
+    console.error(`[Queue System ${guildId}] Error playing track ${trackToPlay.title}: ${error.message}`, error);
+    const errorChannel = trackToPlay.interactionChannel || queueData.lastInteractionChannel || interactionChannel;
+    if (errorChannel) {
+        const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription(`Error al reproducir **${trackToPlay.title}**: ${error.message.substring(0,100)}`);
+        errorChannel.send({ embeds: [errorEmbed] }).catch(console.error);
+    }
+    queueData.currentTrack = null; 
+    playNextInQueue(guildId, interactionChannel); 
+  }
+}
+
+function pauseTrack(guildId) {
+    const player = guildPlayers.get(guildId);
+    if (player && player.state.status === AudioPlayerStatus.Playing) {
+        player.pause();
+        return true;
+    }
+    return false;
+}
+
+function resumeTrack(guildId) {
+    const player = guildPlayers.get(guildId);
+    if (player && player.state.status === AudioPlayerStatus.Paused) {
+        player.unpause();
+        return true;
+    }
+    return false;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('play')
+    .setDescription('Reproduce una canción o la añade a la cola.')
+    .addStringOption(option =>
+      option.setName('query')
+        .setDescription('Nombre de la canción o URL (Spotify, YouTube, SoundCloud, Playlist de Spotify)')
+        .setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.deferred && !interaction.replied) {
+        await interaction.deferReply().catch(console.warn); // Catch if defer fails (e.g. interaction already gone)
+    }
+
+    const userVoiceChannel = interaction.member.voice.channel;
+    if (!userVoiceChannel) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('Debes estar en un canal de voz para usar este comando.');
+      // Use followUp if deferred, editReply otherwise.
+      if (interaction.deferred || interaction.replied) await interaction.followUp({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+      else await interaction.reply({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+      return;
+    }
+
+    let connection = getVoiceConnection(interaction.guild.id);
+    let player = guildPlayers.get(interaction.guild.id);
+    let queueData = guildQueues.get(interaction.guild.id);
+
+    if (!connection) {
+      if (!userVoiceChannel.joinable) {
+          const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No tengo permisos para unirme a tu canal de voz.');
+          if (interaction.deferred || interaction.replied) await interaction.followUp({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+          else await interaction.reply({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+          return;
+      }
+      // Check speak permission before joining
+      if (!userVoiceChannel.speakable && userVoiceChannel.type !== 'GUILD_STAGE_VOICE') { // Stage voice channels have different permission model for speaking (request to speak)
+        const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No tengo permisos para hablar en tu canal de voz.');
+        if (interaction.deferred || interaction.replied) await interaction.followUp({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+        else await interaction.reply({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+        return;
+      }
+      try {
+        console.log(`[Play Command] Attempting to join voice channel: ${userVoiceChannel.name}`);
+        connection = joinVoiceChannel({
+          channelId: userVoiceChannel.id,
+          guildId: interaction.guild.id,
+          adapterCreator: interaction.guild.voiceAdapterCreator,
+          selfDeaf: true,
+        });
+        // Add a Disconnected listener specifically for new connections during /play
+        connection.once(VoiceConnectionStatus.Disconnected, async (oldState, newState) => {
+            // Check if it's a recoverable disconnect or if the connection was destroyed by user/another command
+            if (newState.status === VoiceConnectionStatus.Disconnected && 
+                newState.reason !== undefined && // VoiceConnectionDisconnectReason might be imported for specific reasons
+                connection.state.status !== VoiceConnectionStatus.Destroyed) {
+                try {
+                    console.warn(`[Play Command Connection] Voice Connection for ${interaction.guild.id} was disconnected. Attempting to reconnect...`);
+                    await entersState(connection, VoiceConnectionStatus.Connecting, 5_000); // Try to connect again
+                    await entersState(connection, VoiceConnectionStatus.Ready, 10_000); // Wait for ready
+                    console.log(`[Play Command Connection] Voice Connection for ${interaction.guild.id} reconnected.`);
+                } catch (e) {
+                    console.error(`[Play Command Connection] Voice Connection for ${interaction.guild.id} failed to reconnect after disconnect:`, e);
+                    connection.destroy(); // Destroy if reconnect fails
+                }
+            }
+        });
+        await entersState(connection, VoiceConnectionStatus.Ready, 20_000); // Reduced timeout
+        console.log(`[Play Command] Successfully joined voice channel: ${userVoiceChannel.name}`);
+      } catch (error) {
+        console.error(`[Play Command] Error joining voice channel: ${error.message}`, error);
+        if (connection && connection.state.status !== VoiceConnectionStatus.Destroyed) {
+            connection.destroy();
+        }
+        const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No me pude conectar a tu canal de voz. Verifica mis permisos y que el canal sea accesible.');
+        if (interaction.deferred || interaction.replied) await interaction.followUp({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+        else await interaction.reply({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+        return;
+      }
+    } else if (connection.joinConfig.channelId !== userVoiceChannel.id) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('Estoy en otro canal de voz. Por favor, únete a mi canal o usa `/leave` primero para que pueda unirme al tuyo.');
+      if (interaction.deferred || interaction.replied) await interaction.followUp({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+      else await interaction.reply({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+      return;
+    }
+
+    if (!player) {
+      player = createAudioPlayer();
+      guildPlayers.set(interaction.guild.id, player);
+      connection.subscribe(player);
+
+      if (!guildQueues.has(interaction.guild.id)) {
+        guildQueues.set(interaction.guild.id, { tracks: [], lastInteractionChannel: interaction.channel, nowPlayingMessage: null, currentTrack: null });
+      }
+      queueData = guildQueues.get(interaction.guild.id);
+
+      player.on(AudioPlayerStatus.Idle, () => {
+        console.log(`[AudioPlayer ${interaction.guild.id}] Player is idle.`);
+        const currentQueueData = guildQueues.get(interaction.guild.id);
+        // currentQueueData.currentTrack = null; // Already set to null before calling playNextInQueue or after error in it
+        if (currentQueueData?.nowPlayingMessage) { 
+            currentQueueData.nowPlayingMessage.delete().catch(err => console.warn("Failed to delete old NP message on Idle:", err.message));
+            currentQueueData.nowPlayingMessage = null;
+        }
+        playNextInQueue(interaction.guild.id, currentQueueData?.lastInteractionChannel || interaction.channel);
+      });
+
+      player.on('error', error => {
+        console.error(`[AudioPlayer ${interaction.guild.id}] Error: ${error.message}`, error);
+        const currentQueueData = guildQueues.get(interaction.guild.id);
+        if (currentQueueData) currentQueueData.currentTrack = null;
+        const errorChannel = currentQueueData?.lastInteractionChannel || interaction.channel;
+        const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription(`Ocurrió un error con el reproductor: ${error.message.substring(0,150)}`);
+        errorChannel.send({ embeds: [errorEmbed] }).catch(console.error);
+        playNextInQueue(interaction.guild.id, errorChannel);
+      });
+      
+      connection.on(VoiceConnectionStatus.Destroyed, () => {
+        console.log(`[VoiceConnection ${interaction.guild.id}] Connection destroyed. Cleaning up player and queue.`);
+        if (player) {
+          player.stop(true);
+          guildPlayers.delete(interaction.guild.id);
+        }
+        const qData = guildQueues.get(interaction.guild.id);
+        if (qData?.nowPlayingMessage) {
+            qData.nowPlayingMessage.delete().catch(err => console.warn("Failed to delete NP message on Destroy:", err.message));
+        }
+        guildQueues.delete(interaction.guild.id);
+      });
+    }
+    if (!queueData) {
+        guildQueues.set(interaction.guild.id, { tracks: [], lastInteractionChannel: interaction.channel, nowPlayingMessage: null, currentTrack: null });
+        queueData = guildQueues.get(interaction.guild.id);
+    }
+    queueData.lastInteractionChannel = interaction.channel;
+
+    const query = interaction.options.getString('query');
+    const isSpotifyPlaylist = query.includes('spotify.com/playlist/');
+    const wasPlayerIdle = player.state.status === AudioPlayerStatus.Idle || player.state.status === AudioPlayerStatus.AutoPaused;
+
+    try {
+      if (isSpotifyPlaylist) {
+        if (!interaction.replied) await interaction.editReply({ embeds: [new EmbedBuilder().setColor(0x0099FF).setDescription('Procesando playlist de Spotify... Esto puede tardar un momento.')] });
+        
+        const playlist = await playdl.playlist_info(query, { incomplete: true });
+        if (!playlist || !playlist.videos || playlist.videos.length === 0) { // play-dl v2 uses playlist.videos
+          const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('No se pudo obtener información de la playlist de Spotify o está vacía.');
+          await interaction.editReply({ embeds: [errorEmbed] });
+          return;
+        }
+
+        const tracksToAdd = [];
+        for (const trackInfo of playlist.videos) { // play-dl v2 uses playlist.videos which are already somewhat processed
+            tracksToAdd.push({
+                url: trackInfo.url, // This should be the YouTube URL play-dl found
+                title: trackInfo.title || 'Título Desconocido',
+                duration: trackInfo.durationFormatted || trackInfo.durationRaw || 'N/A', // durationRaw might be in seconds
+                thumbnail: trackInfo.thumbnails?.[0]?.url || null,
+                requester: interaction.user.tag,
+                interactionChannel: interaction.channel
+            });
+        }
+        
+        queueData.tracks.push(...tracksToAdd);
+        console.log(`[Play Command] Added ${tracksToAdd.length} tracks from playlist: ${playlist.name}`);
+
+        const playlistAddedEmbed = new EmbedBuilder()
+            .setColor(0x00FF00)
+            .setTitle('Playlist Añadida a la Cola')
+            .setDescription(`**${playlist.name || 'Playlist de Spotify'}** (${tracksToAdd.length} canciones)`)
+            .setThumbnail(playlist.thumbnail?.url || (tracksToAdd.length > 0 ? tracksToAdd[0].thumbnail : null))
+            .addFields({ name: 'Pedido por', value: interaction.user.tag, inline: true });
+        
+        // Use followup if initial reply was 'Procesando...'
+        await interaction.followUp({ embeds: [playlistAddedEmbed] });
+
+
+      } else { // Single track logic
+        console.log(`[Play Command] Searching for single query: "${query}"`);
+        const searchResults = await playdl.search(query, { limit: 1, source : { youtube : 'video' } }); 
+
+        if (!searchResults || searchResults.length === 0) {
+          const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('No se encontraron resultados para tu búsqueda.');
+          await interaction.editReply({ embeds: [errorEmbed] });
+          return;
+        }
+
+        const trackInfo = searchResults[0];
+        const track = {
+          url: trackInfo.url,
+          title: trackInfo.title || 'Título Desconocido',
+          duration: trackInfo.durationFormatted || 'N/A',
+          thumbnail: trackInfo.thumbnails?.[0]?.url || null,
+          requester: interaction.user.tag,
+          interactionChannel: interaction.channel
+        };
+        
+        queueData.tracks.push(track);
+        console.log(`[Play Command] Added to queue: ${track.title}`);
+
+        if (!wasPlayerIdle) { // If player was already playing, just confirm song added
+            const queueEmbed = new EmbedBuilder()
+            .setColor(0x0099ff)
+            .setTitle('Añadido a la Cola')
+            .setDescription(`**[${track.title}](${track.url})**`)
+            .addFields(
+                { name: 'Pedido por', value: track.requester, inline: true },
+                { name: 'Posición en cola', value: `${queueData.tracks.length}`, inline: true }
+            )
+            .setThumbnail(track.thumbnail)
+            .setFooter({ text: `Duración: ${track.duration}` });
+            await interaction.editReply({ embeds: [queueEmbed] });
+        } else {
+            // If player was idle, playNextInQueue will be called and handle the "Now Playing" message.
+            // We might just editReply with a simple confirmation here, or let playNextInQueue handle it.
+            // For consistency, let playNextInQueue handle the "Now Playing" message.
+            // The deferReply will be fulfilled by the "Now Playing" embed from playNextInQueue.
+            // However, if the interaction was already replied to (e.g. "Procesando playlist"), this won't work.
+            // This path is for single tracks when player was idle.
+            // interaction.editReply might have already been used by "Procesando playlist" if it was a playlist.
+            // This specific editReply for single track when idle might not be needed if playNextInQueue sends the message.
+            // Let's send a minimal confirmation, playNextInQueue will send the full "Now Playing"
+            const simpleAddEmbed = new EmbedBuilder()
+                .setColor(0x00FF00)
+                .setDescription(`Añadido a la cola: **${track.title}**. Empezando reproducción...`);
+            await interaction.editReply({ embeds: [simpleAddEmbed] });
+        }
+      }
+
+      if (wasPlayerIdle) {
+        playNextInQueue(interaction.guild.id, interaction.channel);
+      }
+
+    } catch (error) {
+      console.error(`[Play Command] Error processing query "${query}": ${error.message}`, error);
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000);
+      if (error.message.toLowerCase().includes('authorization') || error.message.toLowerCase().includes('spotify api error')) {
+          errorEmbed.setDescription('Error de autorización con Spotify. Asegúrate de que las credenciales están bien configuradas.');
+      } else if (error.message.toLowerCase().includes('no results found') || error.message.toLowerCase().includes('could not find any video')) {
+          errorEmbed.setDescription('No se encontraron resultados para tu búsqueda o no se pudo extraer el video.');
+      } else if (error.message.toLowerCase().includes('playlist is private or not found')) {
+          errorEmbed.setDescription('La playlist de Spotify es privada o no se encontró.');
+      }
+      else {
+        errorEmbed.setDescription('Ocurrió un error al intentar procesar tu solicitud.');
+      }
+      
+      if (interaction.replied || interaction.deferred) { // Use followUp if already replied/deferred
+         await interaction.followUp({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+      } else {
+         await interaction.reply({ embeds: [errorEmbed], ephemeral: true }).catch(console.warn);
+      }
+    }
+  },
+  playNextInQueue,
+  pauseTrack,
+  resumeTrack,
+  guildPlayers, 
+  guildQueues   
+};

--- a/commands/voice/queue.js
+++ b/commands/voice/queue.js
@@ -1,0 +1,66 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('queue')
+    .setDescription('Muestra la cola de reproducción actual.'),
+  async execute(interaction) {
+    try {
+      // In a more robust setup, this would be accessed via interaction.client.musicManager or similar.
+      const { guildQueues } = require('./play.js'); 
+      // guildPlayers is not strictly needed here if currentTrack is reliably in queueData
+
+      const queueData = guildQueues.get(interaction.guild.id);
+
+      const queueEmbed = new EmbedBuilder()
+        .setColor(0x0099FF)
+        .setTitle('Cola de Reproducción')
+        .setTimestamp();
+
+      let description = '';
+      const currentTrack = queueData?.currentTrack;
+
+      if (currentTrack) {
+        description += `**Reproduciendo Ahora:**\n[${currentTrack.title}](${currentTrack.url}) (Pedido por: ${currentTrack.requester}) - Duración: ${currentTrack.duration}\n\n**Siguiente en la cola:**\n`;
+      } else {
+        description += '**Cola de reproducción:**\n';
+      }
+
+      if (!queueData || !queueData.tracks || queueData.tracks.length === 0) {
+        if (currentTrack) {
+          description += 'No hay más canciones en la cola.';
+        } else {
+          description = 'La cola está vacía y no hay nada reproduciéndose.';
+        }
+      } else {
+        queueData.tracks.slice(0, 10).forEach((track, index) => {
+          description += `${index + 1}. [${track.title}](${track.url}) (Pedido por: ${track.requester}) - Duración: ${track.duration}\n`;
+        });
+        if (queueData.tracks.length > 10) {
+          description += `\n... y ${queueData.tracks.length - 10} más.`;
+        }
+      }
+      
+      queueEmbed.setDescription(description.substring(0, 4090));
+
+      // Handle replies carefully for buttons vs slash commands
+      if (interaction.replied || interaction.deferred) {
+        // If interaction was deferred (e.g. by button handler in index.js), use followUp.
+        // Buttons handled in index.js usually deferUpdate, then followUp ephemerally.
+        await interaction.followUp({ embeds: [queueEmbed], ephemeral: true });
+      } else {
+        // For direct slash command, reply directly.
+        await interaction.reply({ embeds: [queueEmbed], ephemeral: interaction.isButton() }); // Ephemeral if button, public if slash
+      }
+
+    } catch (error) {
+      console.error(`[Queue Command] Error displaying queue: ${error.message}`, error);
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('Ocurrió un error al mostrar la cola.');
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+      } else {
+        await interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+      }
+    }
+  },
+};

--- a/commands/voice/skip.js
+++ b/commands/voice/skip.js
@@ -1,0 +1,53 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { getVoiceConnection, AudioPlayerStatus } = require('@discordjs/voice');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('skip')
+    .setDescription('Salta la canción actual.'),
+  async execute(interaction) {
+    const connection = getVoiceConnection(interaction.guild.id);
+    if (!connection) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No estoy en un canal de voz.');
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+
+    const player = connection.state.subscription?.player;
+
+    if (!player || player.state.status === AudioPlayerStatus.Idle) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('No hay nada reproduciendo actualmente para saltar.');
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+
+    try {
+      const oldStateStatus = player.state.status;
+      player.stop(); 
+      
+      if (oldStateStatus !== AudioPlayerStatus.Idle) {
+        const successEmbed = new EmbedBuilder().setColor(0x00FF00).setDescription('⏭️ Canción saltada.');
+        // If the interaction is from a button, it might have been deferredUpdate.
+        // A new reply is appropriate here, or followUp if the original interaction was deferred.
+        if (interaction.isButton()) {
+            // For buttons, we might want to send a new message or just update the original "Now Playing"
+            // For simplicity now, we'll just reply ephemerally.
+            // The 'idle' handler in play.js will announce the next track.
+            await interaction.reply({ embeds: [successEmbed], ephemeral: true });
+        } else {
+            await interaction.reply({ embeds: [successEmbed] });
+        }
+      } else {
+        const infoEmbed = new EmbedBuilder().setColor(0xFFCC00).setDescription('No había nada reproduciéndose, pero intenté saltar.');
+        await interaction.reply({ embeds: [infoEmbed], ephemeral: true });
+      }
+      
+    } catch (error) {
+      console.error(`[Skip Command] Error skipping track: ${error.message}`, error);
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('Ocurrió un error al intentar saltar la canción.');
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+      } else {
+        await interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+      }
+    }
+  },
+};

--- a/commands/voice/stop.js
+++ b/commands/voice/stop.js
@@ -1,0 +1,59 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { getVoiceConnection } = require('@discordjs/voice');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('stop')
+    .setDescription('Detiene la música y limpia la cola de reproducción.'),
+  async execute(interaction) {
+    const connection = getVoiceConnection(interaction.guild.id);
+    if (!connection) {
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('No estoy en un canal de voz.');
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+    }
+
+    try {
+      const { guildPlayers, guildQueues } = require('./play.js'); 
+
+      const player = guildPlayers.get(interaction.guild.id);
+      const queueData = guildQueues.get(interaction.guild.id);
+
+      if (player) {
+        player.stop(true); 
+        // Player map entry is cleaned up by VoiceConnection.Destroyed listener in play.js if connection is also destroyed (e.g. by /leave)
+        // If only stopping, player object remains for potential reuse.
+      }
+
+      if (queueData) {
+        queueData.tracks = []; // Clear the tracks array
+        queueData.currentTrack = null; // Clear current track
+        if (queueData.nowPlayingMessage) {
+            queueData.nowPlayingMessage.delete().catch(err => console.warn("[Stop Command] Failed to delete NP message:", err.message));
+            queueData.nowPlayingMessage = null;
+        }
+        // The queueData object itself (and its entry in guildQueues map) is cleared by VoiceConnection.Destroyed or /leave.
+        // Here, we only empty its contents.
+      }
+      
+      const replyEmbed = new EmbedBuilder()
+        .setColor(0x00FF00)
+        .setDescription('⏹️ Música detenida y cola limpiada. Si quieres que me vaya del canal, usa `/leave`.');
+
+      // Handle reply/followUp correctly, especially for button interactions
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ embeds: [replyEmbed], ephemeral: true });
+      } else {
+        await interaction.reply({ embeds: [replyEmbed], ephemeral: true }); // Ephemeral for slash command too for less chat clutter
+      }
+
+    } catch (error) {
+      console.error(`[Stop Command] Error stopping music: ${error.message}`, error);
+      const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription('Ocurrió un error al intentar detener la música.');
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+      } else {
+        await interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+      }
+    }
+  },
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "express": "^5.1.0",
     "googleapis": "^149.0.0",
     "openai": "^4.98.0",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "@discordjs/voice": "^0.17.0",
+    "libsodium-wrappers": "^0.7.13",
+    "opusscript": "^0.1.1",
+    "ffmpeg-static": "^5.2.0",
+    "play-dl": "^1.9.7",
+    "spotify-web-api-node": "^5.0.2"
   }
 }

--- a/spotifyService.js
+++ b/spotifyService.js
@@ -1,0 +1,160 @@
+const SpotifyWebApi = require('spotify-web-api-node');
+let config = {}; // To be loaded from config.json
+try {
+  // Assuming spotifyService.js is in the root, alongside config.json
+  config = require('./config.json'); 
+} catch (error) {
+  console.error('[Spotify Service] Could not load config.json. Spotify features will not work. Error:', error.message);
+}
+
+// Import play-dl
+const playdl = require('play-dl');
+
+const spotifyApi = new SpotifyWebApi({
+  // Credentials will be set in initializeSpotifyClient if loaded from config
+  // Setting them here directly from `config` might fail if config.json is missing at this point
+});
+
+let clientInitialized = false;
+let tokenRefreshTimeout = null;
+
+async function initializeSpotifyClient() {
+  if (tokenRefreshTimeout) {
+    clearTimeout(tokenRefreshTimeout); // Clear any existing refresh timeout
+    tokenRefreshTimeout = null;
+  }
+
+  if (!config.spotifyClientId || !config.spotifyClientSecret) {
+    console.error('[Spotify Service] Spotify Client ID or Client Secret not found in config.json.');
+    clientInitialized = false;
+    return false;
+  }
+  
+  // Set credentials
+  spotifyApi.setClientId(config.spotifyClientId);
+  spotifyApi.setClientSecret(config.spotifyClientSecret);
+
+  try {
+    const data = await spotifyApi.clientCredentialsGrant();
+    console.log('[Spotify Service] Spotify access token obtained.');
+    spotifyApi.setAccessToken(data.body['access_token']);
+    
+    const expiresIn = data.body['expires_in']; // seconds
+    // Schedule token refresh a bit before it expires (e.g., 1 minute before)
+    // Ensures that we request a new token before the current one becomes invalid.
+    if (expiresIn > 60) {
+        tokenRefreshTimeout = setTimeout(initializeSpotifyClient, (expiresIn - 60) * 1000); 
+        console.log(`[Spotify Service] Token will be refreshed in approx. ${(expiresIn - 60) / 60} minutes.`);
+    } else {
+        // If expires_in is very short, refresh sooner, e.g., halfway through
+        tokenRefreshTimeout = setTimeout(initializeSpotifyClient, (expiresIn / 2) * 1000);
+        console.log(`[Spotify Service] Token has a short expiry. Refreshing in approx. ${expiresIn / 2} seconds.`);
+    }
+    
+    clientInitialized = true;
+    return true;
+  } catch (error) {
+    console.error('[Spotify Service] Error obtaining Spotify access token:', error.message || error);
+    if (error.body) console.error('[Spotify Service] Error body:', JSON.stringify(error.body));
+    clientInitialized = false;
+    
+    // Optional: Retry initialization after a delay if it's a network issue or temporary hiccup
+    // For now, we'll just log the error. A more robust implementation might retry a few times.
+    // setTimeout(initializeSpotifyClient, 60 * 1000); // Retry after 1 minute
+    return false;
+  }
+}
+
+async function searchSpotifyTrack(trackName) {
+  if (!clientInitialized) {
+    console.warn('[Spotify Service] Spotify client not initialized or token not available. Attempting to initialize...');
+    const success = await initializeSpotifyClient();
+    if (!success) {
+        console.error('[Spotify Service] Initialization failed. Cannot search track.');
+        return null;
+    }
+    // If initialization was successful, clientInitialized is now true.
+  }
+
+  try {
+    console.log(`[Spotify Service] Searching for track: "${trackName}"`);
+    const searchResult = await spotifyApi.searchTracks(trackName, { limit: 1 });
+    if (searchResult.body && searchResult.body.tracks && searchResult.body.tracks.items.length > 0) {
+      const track = searchResult.body.tracks.items[0];
+      console.log(`[Spotify Service] Found track: ${track.name} by ${track.artists.map(a => a.name).join(', ')} (ID: ${track.id})`);
+      return track;
+    } else {
+      console.log(`[Spotify Service] No tracks found for "${trackName}"`);
+      return null;
+    }
+  } catch (error) {
+    console.error(`[Spotify Service] Error searching track "${trackName}":`, error.message || error);
+    if (error.body) console.error('[Spotify Service] Error body:', JSON.stringify(error.body));
+    
+    // Handle token expiration (401 Unauthorized)
+    if (error.statusCode === 401 && error.message.includes('token expired')) {
+        console.log('[Spotify Service] Access token expired. Attempting to refresh and retry search...');
+        const refreshed = await initializeSpotifyClient(); // This will get a new token
+        if (refreshed) {
+            console.log('[Spotify Service] Token refreshed successfully. Retrying search...');
+            return searchSpotifyTrack(trackName); // Retry the search with the new token
+        } else {
+            console.error('[Spotify Service] Failed to refresh token. Cannot retry search.');
+        }
+    }
+    return null;
+  }
+}
+
+module.exports = {
+  initializeSpotifyClient,
+  searchSpotifyTrack,
+  getSpotifyClient: () => clientInitialized ? spotifyApi : null
+};
+
+// New function to configure play-dl with Spotify credentials
+async function configurePlayDlSpotify() {
+  if (config.spotifyClientId && config.spotifyClientSecret) {
+    try {
+      await playdl.setToken({
+        spotify: {
+          client_id: config.spotifyClientId,
+          client_secret: config.spotifyClientSecret,
+          market: 'US' // Or your preferred market, e.g., 'ES' for Spain
+        }
+      });
+      console.log('[PlayDL] Spotify token configured successfully for play-dl.');
+      return true;
+    } catch (e) {
+      console.error('[PlayDL] Failed to set Spotify token for play-dl:', e.message || e);
+      return false;
+    }
+  } else {
+    console.warn('[PlayDL] Spotify Client ID or Client Secret not found in config.json. Play-dl Spotify features might be limited.');
+    return false;
+  }
+}
+
+// Keep a reference to the original initializeSpotifyClient
+const originalInitializeSpotifyClient = initializeSpotifyClient;
+
+// Redefine initializeSpotifyClient to also attempt play-dl configuration
+initializeSpotifyClient = async () => {
+  // Call the original function
+  const success = await originalInitializeSpotifyClient(); 
+  if (success) {
+    // If the original initialization was successful, also configure play-dl
+    // We don't want play-dl configuration failure to prevent the main Spotify client from working,
+    // so we don't return its success status directly unless that's desired.
+    await configurePlayDlSpotify(); 
+  }
+  return success; // Return the success status of the original Spotify client initialization
+};
+
+
+module.exports = {
+  initializeSpotifyClient,
+  searchSpotifyTrack,
+  getSpotifyClient: () => clientInitialized ? spotifyApi : null,
+  configurePlayDlSpotify // Exporting this separately in case it needs to be called independently
+};


### PR DESCRIPTION
Adds a comprehensive music playback feature with Spotify integration.

Key functionalities include:
- Core Playback:
  - `/play [query/URL]`: Plays songs or Spotify tracks/playlists. Uses `play-dl` to resolve Spotify links and stream audio, typically from YouTube/SoundCloud.
  - Joins your voice channel automatically if not connected.
- Queue Management:
  - Songs are added to a queue if one is already playing.
  - `/skip`: Skips the current song.
  - `/stop`: Stops playback and clears the queue.
  - `/queue`: Displays the current song queue.
- Voice Channel Control:
  - `/join`: Bot joins your voice channel.
  - `/leave`: Bot leaves the voice channel, clears queue, and stops player.
- Spotify Integration:
  - `spotifyService.js` handles Spotify API authentication (Client Credentials).
  - Configures `play-dl` with Spotify credentials for improved track/playlist resolution.
- User Interface:
  - Extensive use of embeds for messages (Now Playing, Added to Queue, Errors, etc.).
  - Interactive buttons on the "Now Playing" message for Pause/Resume, Skip, Stop, and View Queue.
- Error Handling & Robustness:
  - Comprehensive error handling for API calls, stream issues, voice connections.
  - Graceful handling of edge cases (e.g., empty queues, invalid inputs, permissions).
  - State cleanup on disconnections or errors.

This feature allows you to play music from Spotify (and other sources supported by `play-dl`) with a rich, interactive interface.