### PR TITLE
Refactor(play): Usar video_basic_info y stream_from_info para obtener…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1952,7 +1952,6 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/play-dl/-/play-dl-1.9.7.tgz",
       "integrity": "sha512-KpgerWxUCY4s9Mhze2qdqPhiqd8Ve6HufpH9mBH3FN+vux55qSh6WJKDabfie8IBHN7lnrAlYcT/UdGax58c2A==",
-      "license": "GPL-3.0",
       "dependencies": {
         "play-audio": "^0.5.2"
       },


### PR DESCRIPTION
… streams

He modificado la lógica de reproducción en `playNextInQueue` para mejorar la robustez al obtener streams de audio de play-dl.

Cambios principales:
- En lugar de llamar directamente a `playdl.stream(url)`, ahora primero obtengo la información del video usando `playdl.video_basic_info(url)`.
- Luego, el stream de audio se obtiene llamando a `playdl.stream_from_info(videoInfo)`.
- He añadido un bloque try-catch específico para el paso de `video_basic_info`. Si fallo al obtener esta información, registro un error, te notifico y salto la canción.
- El bloque try-catch existente se mantiene para errores durante `stream_from_info` o la creación del AudioResource.

Este enfoque de dos pasos podría resolver problemas donde `playdl.stream()` falla internamente al intentar resolver la URL del stream, como el error persistente "Invalid URL AudioPlayerError [TypeError]: Invalid URL".