### PR TITLE
Feat(play): Implementar streaming de YouTube con ytdl-core-discord

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "opusscript": "^0.1.1",
         "play-dl": "^1.9.7",
         "spotify-web-api-node": "^5.0.2",
-        "xml2js": "^0.6.2"
+        "xml2js": "^0.6.2",
+        "ytdl-core-discord": "^1.3.1"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -1569,6 +1570,18 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
     },
+    "node_modules/m3u8stream": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+      "dependencies": {
+        "miniget": "^4.2.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-bytes.js": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
@@ -1678,6 +1691,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/miniget": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
+      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -2601,6 +2622,66 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/ytdl-core": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
+      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
+      "dependencies": {
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.2",
+        "sax": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ytdl-core-discord": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ytdl-core-discord/-/ytdl-core-discord-1.3.1.tgz",
+      "integrity": "sha512-KW8zYY35jRSkxZTEQtT9EiR2exFwYKhCE8QZbRg5Ge9a0YWDDhBOixSdWb8Cn41B1uHhz8FR15E4E/k0kHNX3w==",
+      "dependencies": {
+        "@types/node": "^15.12.2",
+        "prism-media": "^1.3.1",
+        "ytdl-core": "^4.8.2"
+      }
+    },
+    "node_modules/ytdl-core-discord/node_modules/@types/node": {
+      "version": "15.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "node_modules/ytdl-core-discord/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/ytdl-core-discord/node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "opusscript": "^0.1.1",
     "play-dl": "^1.9.7",
     "spotify-web-api-node": "^5.0.2",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "ytdl-core-discord": "^1.3.1"
   }
 }


### PR DESCRIPTION
Se refactoriza el comando de reproducción para utilizar `ytdl-core-discord` para obtener streams de audio de YouTube, reemplazando el uso problemático de `play-dl` para esta fuente específica.

Cambios principales:
- Se ha añadido `ytdl-core-discord` como dependencia del proyecto.
- La función `playNextInQueue` ahora detecta si la URL de la canción es de YouTube.
  - Si es una URL de YouTube, se utiliza `ytdl()` para obtener un stream Opus directamente. Este stream se pasa a `createAudioResource` especificando `StreamType.Opus`.
  - Si la URL no es de YouTube, se mantiene la lógica anterior que utiliza `playdl.video_basic_info()` y `playdl.stream_from_info()`, asumiendo que `play-dl` puede manejar otras fuentes (ej. SoundCloud, Spotify).
- Se ha añadido `StreamType` a las importaciones de `@discordjs/voice`.
- La funcionalidad de búsqueda de canciones (`playdl.search()`) no se ha modificado en este commit y seguirá siendo utilizada para obtener la URL inicial y los metadatos de las canciones buscadas por nombre.

Este cambio tiene como objetivo resolver los errores persistentes de "Invalid URL" que ocurrían con `play-dl` al intentar reproducir videos de YouTube, proporcionando un método de streaming más robusto y directo para esta plataforma.