### PR TITLE
Fix(play): Usar ytdl-core para streaming de YouTube

### DIFF
--- a/commands/voice/play.js
+++ b/commands/voice/play.js
@@ -10,7 +10,7 @@ const {
   StreamType
 } = require('@discordjs/voice');
 const playdl = require('play-dl');
-const ytdl = require('ytdl-core-discord');
+const ytdl = require('ytdl-core');
 
 const guildPlayers = new Map(); // guildId -> AudioPlayer
 const guildQueues = new Map(); // guildId -> { tracks: [], lastInteractionChannel: null, nowPlayingMessage: null, currentTrack: null }
@@ -80,17 +80,17 @@ async function playNextInQueue(guildId, interactionChannel) {
     let streamType = StreamType.Arbitrary; // Default for play-dl
 
     if (trackToPlay.url.includes('youtube.com/') || trackToPlay.url.includes('youtu.be/')) {
-      console.log(`[Queue System ${guildId}] Identified YouTube URL for ${trackToPlay.title}. Attempting to stream with ytdl-core-discord.`);
+      console.log(`[Queue System ${guildId}] Identified YouTube URL for ${trackToPlay.title}. Attempting to stream with ytdl-core.`);
       try {
         streamData = await ytdl(trackToPlay.url, {
           filter: 'audioonly',
           quality: 'highestaudio',
           highWaterMark: 1 << 25,
         });
-        streamType = StreamType.Opus; // ytdl-core-discord provides an Opus stream
-        console.log(`[Queue System ${guildId}] Successfully obtained Opus stream with ytdl-core-discord for: ${trackToPlay.title}`);
+        streamType = StreamType.Arbitrary; // ytdl-core output type can vary, let discordjs/voice infer.
+        console.log(`[Queue System ${guildId}] Successfully obtained stream with ytdl-core for: ${trackToPlay.title}`);
       } catch (ytdlError) {
-        console.error(`[Queue System ${guildId}] Error streaming with ytdl-core-discord for ${trackToPlay.title} (URL: ${trackToPlay.url}): ${ytdlError.message}`, ytdlError);
+        console.error(`[Queue System ${guildId}] Error streaming with ytdl-core for ${trackToPlay.title} (URL: ${trackToPlay.url}): ${ytdlError.message}`, ytdlError);
         const errorChannel = queueData?.lastInteractionChannel || trackToPlay.interactionChannel || interactionChannel;
         if (errorChannel) {
           const errorEmbed = new EmbedBuilder().setColor(0xFF0000).setDescription(`Error al procesar la canción de YouTube **${trackToPlay.title}** con ytdl: ${ytdlError.message.substring(0,150)}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "play-dl": "^1.9.7",
         "spotify-web-api-node": "^5.0.2",
         "xml2js": "^0.6.2",
-        "ytdl-core-discord": "^1.3.1"
+        "ytdl-core": "^4.11.5"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -2634,53 +2634,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ytdl-core-discord": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ytdl-core-discord/-/ytdl-core-discord-1.3.1.tgz",
-      "integrity": "sha512-KW8zYY35jRSkxZTEQtT9EiR2exFwYKhCE8QZbRg5Ge9a0YWDDhBOixSdWb8Cn41B1uHhz8FR15E4E/k0kHNX3w==",
-      "dependencies": {
-        "@types/node": "^15.12.2",
-        "prism-media": "^1.3.1",
-        "ytdl-core": "^4.8.2"
-      }
-    },
-    "node_modules/ytdl-core-discord/node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
-    },
-    "node_modules/ytdl-core-discord/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/ytdl-core-discord/node_modules/prism-media": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
-      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
-      "peerDependencies": {
-        "@discordjs/opus": ">=0.8.0 <1.0.0",
-        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "play-dl": "^1.9.7",
     "spotify-web-api-node": "^5.0.2",
     "xml2js": "^0.6.2",
-    "ytdl-core-discord": "^1.3.1"
+    "ytdl-core": "^4.11.5"
   }
 }


### PR DESCRIPTION
He reemplazado `ytdl-core-discord` con `ytdl-core` (v4.11.5) para manejar el streaming de audio desde YouTube. Este cambio busca resolver errores persistentes como "Could not extract functions" que indicaban problemas con el descifrado de la firma de YouTube.

Cambios principales:
- He desinstalado `ytdl-core-discord` y añadido `ytdl-core` como dependencia.
- La función `playNextInQueue` en `commands/voice/play.js` ha sido actualizada:
  - He cambiado la importación para usar `require('ytdl-core')`.
  - Para streams de YouTube obtenidos con `ytdl()`, el `inputType` en `createAudioResource` ahora se establece como `StreamType.Arbitrary`.
- La lógica para manejar otras fuentes (SoundCloud, Spotify, etc.) a través de `play-dl` permanece sin cambios.
- La funcionalidad de búsqueda (`playdl.search()`) no ha sido modificada.

Este es un intento de estabilizar la reproducción de YouTube utilizando una biblioteca más fundamental y frecuentemente actualizada para la interacción con YouTube.