### PR TITLE
refactor: Centralizar configuración en config.js y actualizar README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,32 +8,58 @@ Este es un bot multifuncional para Discord con varias características avanzadas
 El dashboard web integrado permite a los administradores de servidor configurar fácilmente las reglas de AutoMod para sus respectivos servidores de Discord a través de una interfaz gráfica amigable.
 
 ### Configuración Inicial
-Para que el bot y el dashboard web funcionen correctamente, es necesario configurar las siguientes variables de entorno:
+La configuración del bot y del dashboard web se gestiona principalmente a través del archivo `config.js` ubicado en la raíz del proyecto. Este archivo utiliza el paquete `dotenv` para cargar automáticamente valores desde un archivo `.env` si existe.
 
--   `TOKEN`: El token de tu bot de Discord. Esencial para que el bot se conecte a Discord.
--   `DISCORD_CLIENT_ID`: El ID de cliente de tu aplicación de Discord. Necesario para la autenticación OAuth2 para el dashboard.
--   `DISCORD_CLIENT_SECRET`: El secreto de cliente de tu aplicación de Discord. Necesario para la autenticación OAuth2.
--   `DISCORD_REDIRECT_URI`: La URI de redirección OAuth2 configurada en tu aplicación de Discord. Por defecto, para desarrollo local, debería ser algo como `http://localhost:3000/auth/discord/callback`.
--   `SESSION_SECRET`: Una cadena aleatoria y secreta utilizada para asegurar las sesiones de usuario en el dashboard web.
--   `PORT`: El puerto en el que se ejecutará el servidor web del dashboard (por defecto, 3000 si no se especifica).
+**Pasos recomendados para la configuración:**
 
-**Cómo obtener credenciales de Discord:**
+1.  **Crear un archivo `.env`**: En la raíz del proyecto, crea un archivo llamado `.env`. Este archivo es ignorado por Git (a través de `.gitignore`, si está configurado) y es ideal para almacenar tus credenciales y configuraciones locales.
+2.  **Poblar el archivo `.env`**: Añade las siguientes variables a tu archivo `.env`, reemplazando los valores de ejemplo con tus propias credenciales:
+
+    ```env
+    # Token de tu Bot de Discord
+    TOKEN=tu_token_de_bot_aqui
+
+    # Credenciales de la Aplicación de Discord para OAuth2 (Dashboard Web)
+    DISCORD_CLIENT_ID=tu_id_de_cliente_aqui
+    DISCORD_CLIENT_SECRET=tu_secreto_de_cliente_aqui
+    DISCORD_REDIRECT_URI=http://localhost:3000/auth/discord/callback # Ajusta si tu puerto o dominio es diferente
+
+    # Secreto para las sesiones del Dashboard Web
+    SESSION_SECRET=una_cadena_larga_aleatoria_y_segura_para_las_sesiones
+
+    # Puerto para el Dashboard Web (opcional, por defecto es 3000)
+    PORT=3000
+    ```
+
+3.  **Entender `config.js`**:
+    *   El archivo `config.js` intentará leer estas variables desde tu `.env`.
+    *   Si alguna variable no se encuentra en `.env`, `config.js` proporcionará valores placeholder o por defecto (ej. para `discordRedirectUri` y `webServerPort`).
+    *   **Es crucial que `TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, y `SESSION_SECRET` estén correctamente configurados, ya sea en `.env` o directamente en `config.js` (aunque no se recomienda para producción o si compartes el código).**
+
+**Variables de Configuración Clave (a través de `.env` o en `config.js`):**
+
+-   `token`: El token de tu bot de Discord. Esencial para que el bot se conecte.
+-   `discordClientId`: El ID de Cliente de tu aplicación de Discord.
+-   `discordClientSecret`: El Secreto de Cliente de tu aplicación de Discord.
+-   `discordRedirectUri`: La URI de redirección OAuth2.
+    *   Para desarrollo local: `http://localhost:3000/auth/discord/callback` (si usas el puerto 3000).
+    *   Para producción: Deberá ser la URL pública donde tu dashboard esté accesible, seguida de `/auth/discord/callback`.
+-   `sessionSecret`: Una cadena larga, aleatoria y segura utilizada para proteger las sesiones de usuario. ¡Cámbiala del valor por defecto!
+-   `webServerPort`: El puerto en el que se ejecutará el servidor web. Se toma de la variable de entorno `PORT` o usa `3000` por defecto.
+
+**Cómo obtener las credenciales de Discord (`token`, `discordClientId`, `discordClientSecret`):**
 1.  Ve al [Portal de Desarrolladores de Discord](https://discord.com/developers/applications).
-2.  Crea una nueva aplicación.
-3.  En la pestaña "Bot", crea un bot y copia el `TOKEN`.
-4.  En la pestaña "OAuth2" -> "General":
-    *   Copia el `CLIENT ID` y el `CLIENT SECRET`.
-    *   En la sección "Redirects", añade la URI que usarás (ej. `http://localhost:3000/auth/discord/callback`). Asegúrate de que coincida exactamente con `DISCORD_REDIRECT_URI`.
-
-Se recomienda crear un archivo `.env` en la raíz del proyecto para gestionar estas variables:
-```env
-TOKEN=tu_token_de_bot
-DISCORD_CLIENT_ID=tu_client_id
-DISCORD_CLIENT_SECRET=tu_client_secret
-DISCORD_REDIRECT_URI=http://localhost:3000/auth/discord/callback
-SESSION_SECRET=tu_secreto_de_sesion_muy_seguro
-PORT=3000
-```
+2.  Crea una "Nueva Aplicación" o selecciona una existente.
+3.  **Para el `token` del bot**:
+    *   Navega a la pestaña "Bot".
+    *   Haz clic en "Add Bot" (si es una nueva aplicación).
+    *   Puedes ver/copiar el token haciendo clic en "Reset Token" o "View Token" (si ya existe). ¡Trata este token como una contraseña!
+4.  **Para `discordClientId` y `discordClientSecret`**:
+    *   Navega a la pestaña "OAuth2" -> "General".
+    *   Aquí encontrarás el "CLIENT ID" (`discordClientId`).
+    *   Puedes ver/copiar el "CLIENT SECRET" (`discordClientSecret`) haciendo clic en "Reset Secret".
+5.  **Para `discordRedirectUri`**:
+    *   En la misma pestaña "OAuth2" -> "General", en la sección "Redirects", añade la URI completa. Por ejemplo: `http://localhost:3000/auth/discord/callback`. Asegúrate de que esta URI coincida exactamente con la que configuras en `DISCORD_REDIRECT_URI` en tu archivo `.env` o `config.js`.
 
 ### Acceso y Uso
 1.  **Iniciar el Bot y Servidor Web**: Ejecuta `node index.js` en la terminal desde la raíz del proyecto. Esto iniciará tanto el bot de Discord como el servidor web para el dashboard.

--- a/index.js
+++ b/index.js
@@ -152,23 +152,22 @@ client.once(Events.ClientReady, async readyClient => {
         // server.js already handles PORT definition and its own startup logging
         // We just need to ensure app.listen is called.
         // The PORT used by app.listen is defined within server.js
-        // No need to redefine it here unless we want to override server.js logic, which is not the case.
-        // Note: server.js uses process.env.PORT || 3000
-        const webServerPort = process.env.PORT || 3000; // For logging consistency here
+        // server.js now gets its port from config.webServerPort
+        // config.js handles PORT environment variable and default
+        const webServerPort = config.webServerPort;
 
-        // Check for essential environment variables for the web server
-        if (!process.env.SESSION_SECRET) {
-            logger.warn('Advertencia: SESSION_SECRET no está configurada. Usando un secreto por defecto e inseguro para la gestión de sesiones.');
-        }
-        if (!process.env.DISCORD_CLIENT_ID || !process.env.DISCORD_CLIENT_SECRET) {
-            logger.warn('Advertencia: DISCORD_CLIENT_ID o DISCORD_CLIENT_SECRET no están configuradas. Discord OAuth2 no funcionará correctamente.');
-        }
-        if (!process.env.DISCORD_REDIRECT_URI) {
-            logger.warn('Advertencia: DISCORD_REDIRECT_URI no está configurada. El callback de Discord OAuth2 podría fallar.');
-        }
+        // Warnings for missing DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, SESSION_SECRET
+        // are now handled in config.js upon its import.
+        // TOKEN warning is also in config.js
+        // No need to repeat them here unless for specific context not covered by config.js.
+
+        // A general check if config exists or critical values are missing can be added here if needed,
+        // but config.js already logs issues.
 
         app.listen(webServerPort, () => {
             logger.info(`🌐 Servidor web dashboard escuchando en http://localhost:${webServerPort}`);
+            // Log essential URLs or info related to the web server if helpful
+            logger.info(`🔑 OAuth2 Redirect URI configurada: ${config.discordRedirectUri}`);
         });
 
     } catch (error) {

--- a/server.js
+++ b/server.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import session from 'express-session';
+import { config } from './config.js'; // Import config
 import authRouter from './server/auth.js';
-import autoModRouter from './server/routes/automod.js'; // Import the new automod router
+import autoModRouter from './server/routes/automod.js';
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = config.webServerPort; // Use port from config
 
 // Middleware to parse JSON bodies
 app.use(express.json());
@@ -16,7 +17,7 @@ app.use(express.static('server/public'));
 // Note: In a production environment, the secret should be a strong, unique string
 // ideally stored in an environment variable.
 app.use(session({
-  secret: process.env.SESSION_SECRET || 'a_placeholder_secret_key_that_should_be_changed',
+  secret: config.sessionSecret, // Use session secret from config
   resave: false, // Do not save session if unmodified
   saveUninitialized: false, // Do not create session until something stored
   cookie: {

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,15 +1,15 @@
 import express from 'express';
 import axios from 'axios';
+import { config } from '../../config.js'; // Import config
 
 const router = express.Router();
 
-// Placeholder for Discord OAuth2 credentials and configuration
-const DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID || 'YOUR_DISCORD_CLIENT_ID';
-const DISCORD_CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET || 'YOUR_DISCORD_CLIENT_SECRET';
-const DISCORD_REDIRECT_URI = process.env.DISCORD_REDIRECT_URI || 'http://localhost:3000/auth/discord/callback'; // Adjust port if needed
+// Use values from config.js
+const DISCORD_CLIENT_ID = config.discordClientId;
+const DISCORD_CLIENT_SECRET = config.discordClientSecret;
+const DISCORD_REDIRECT_URI = config.discordRedirectUri;
 
 // Session middleware is now handled globally in server.js
-// router.use(session({...})); // Removed
 
 // Route to initiate Discord OAuth2 login
 router.get('/discord', (req, res) => {


### PR DESCRIPTION
He refactorizado la gestión de la configuración para centralizarla en un nuevo archivo `config.js`. Este archivo utiliza `dotenv` para cargar variables desde un `.env` local, pero también define valores por defecto o placeholders.

Cambios:
- He creado `config.js` para manejar todas las configuraciones críticas (token del bot, credenciales de Discord OAuth2, secreto de sesión, puerto del servidor web).
- He modificado `server/auth.js`, `server.js`, e `index.js` para obtener sus configuraciones desde el nuevo `config.js` en lugar de usar `process.env` directamente para la mayoría de los valores.
- He actualizado `README.md` para reflejar el nuevo método de configuración, explicando el uso de `config.js` y archivos `.env`.

Este cambio responde a tu feedback para facilitar la configuración en diferentes entornos de hosting como Render.com y mejora la organización general de las configuraciones del proyecto.